### PR TITLE
make test work even if the output directory for test assembly moves around

### DIFF
--- a/src/Rezoom.SQL.Test/Environment.fs
+++ b/src/Rezoom.SQL.Test/Environment.fs
@@ -11,8 +11,8 @@ open Rezoom.SQL.Mapping
 open Rezoom.SQL.Compiler
 
 let userModelByName name =
-    let assemblyFolder = Path.GetDirectoryName(Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath)
-    let resolutionFolder = Path.Combine(assemblyFolder, "../../" + name)
+    let assemblyFolder = __SOURCE_DIRECTORY__
+    let resolutionFolder = Path.Combine(assemblyFolder, name)
     UserModel.Load(resolutionFolder, ".")
 
 let userModel1() = userModelByName "user-model-1"


### PR DESCRIPTION
when migrating to new SDK, the default output directory of assemblies move one level deeper, this PR just adjusts the test to work disregarding where the assembly is running from.