### PR TITLE
better exception message when sql contains qualified table name

### DIFF
--- a/src/Rezoom.SQL.Compiler/Error.fs
+++ b/src/Rezoom.SQL.Compiler/Error.fs
@@ -43,8 +43,11 @@ let columnAlreadyExists name =
     sprintf "SQ018: Column ``%O`` already exists" name
 let noSuchColumnToSet tbl col =
     sprintf "SQ019: No such column in table ``%O`` to set: ``%O``" tbl col
-let noSuchSchema schema =
-    sprintf "SQ020: No such schema: ``%O``" schema
+let noSuchSchema existingSchemas schema =
+    sprintf 
+      "SQ020: No such schema: ``%O``, existing schemas: %s." 
+        schema
+        (existingSchemas |> Map.toArray |> Array.map (fst >> sprintf "``%O``") |> String.concat ", ")
 let ambiguousColumn name =
     sprintf "SQ021: Ambiguous column: ``%O``" name
 let ambiguousColumnBetween name tbl1 tbl2 =

--- a/src/Rezoom.SQL.Compiler/InferredTypes.fs
+++ b/src/Rezoom.SQL.Compiler/InferredTypes.fs
@@ -290,15 +290,9 @@ and [<NoComparison>]
                 | None ->
                     let schema = this.Model.Schemas.[this.Model.DefaultSchema]
                     this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
-        | Some schema ->
-            this.Model.Schemas
-            |> Map.tryFind schema
-            |> function
-               | Some schema -> this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
-               | None ->
-                   schema
-                   |> Error.noSuchSchema this.Model.Schemas
-                   |> failAt name.Source                  
+        | Some schemaName ->
+            let schema = { Source = name.Source; Value = Some schemaName } |> ModelOps.getRequiredSchema |> State.runForOuputValue this.Model
+            this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
 
     /// Resolve a column reference, which may be qualified with a table alias.
     /// This resolves against the tables referenced in the FROM clause, and the columns explicitly named

--- a/src/Rezoom.SQL.Compiler/InferredTypes.fs
+++ b/src/Rezoom.SQL.Compiler/InferredTypes.fs
@@ -295,11 +295,10 @@ and [<NoComparison>]
             |> Map.tryFind schema
             |> function
                | Some schema -> this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
-               | None -> let quote input = "'" + input + "'" in 
-                            failwithf "Schema '%s' doesn't exist. Existing schemas: %s."
-                              (schema |> string |> quote)
-                              (this.Model.Schemas |> Map.toArray |> Array.map (fst >> string >> quote) |> String.concat ", ")
-                
+               | None ->
+                   schema
+                   |> Error.noSuchSchema this.Model.Schemas
+                   |> failAt name.Source                  
 
     /// Resolve a column reference, which may be qualified with a table alias.
     /// This resolves against the tables referenced in the FROM clause, and the columns explicitly named

--- a/src/Rezoom.SQL.Compiler/InferredTypes.fs
+++ b/src/Rezoom.SQL.Compiler/InferredTypes.fs
@@ -291,8 +291,15 @@ and [<NoComparison>]
                     let schema = this.Model.Schemas.[this.Model.DefaultSchema]
                     this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
         | Some schema ->
-            let schema = this.Model.Schemas.[schema]
-            this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
+            this.Model.Schemas
+            |> Map.tryFind schema
+            |> function
+               | Some schema -> this.ResolveObjectReferenceBySchema(schema, name.ObjectName, inferView)
+               | None -> let quote input = "'" + input + "'" in 
+                            failwithf "Schema '%s' doesn't exist. Existing schemas: %s."
+                              (schema |> string |> quote)
+                              (this.Model.Schemas |> Map.toArray |> Array.map (fst >> string >> quote) |> String.concat ", ")
+                
 
     /// Resolve a column reference, which may be qualified with a table alias.
     /// This resolves against the tables referenced in the FROM clause, and the columns explicitly named

--- a/src/Rezoom.SQL.Compiler/ModelOps.fs
+++ b/src/Rezoom.SQL.Compiler/ModelOps.fs
@@ -32,9 +32,9 @@ let getRequiredSchema (schemaName: Name option WithSource) =
         let! model = State.get
         let source = schemaName.Source
         let schemaName =
-          match schemaName.Value with
-          | None -> model.DefaultSchema
-          | Some name -> name
+            match schemaName.Value with
+            | None -> model.DefaultSchema
+            | Some name -> name
         let! schema = getSchema schemaName
         return
             match schema with

--- a/src/Rezoom.SQL.Compiler/ModelOps.fs
+++ b/src/Rezoom.SQL.Compiler/ModelOps.fs
@@ -28,7 +28,7 @@ let private requireNoObject (name : QualifiedObjectName WithSource) =
     }
 
 let getRequiredSchema (schemaName: Name option WithSource) =
-        stateful {
+    stateful {
         let! model = State.get
         let source = schemaName.Source
         let schemaName =

--- a/src/Rezoom.SQL.Test/Environment.fs
+++ b/src/Rezoom.SQL.Test/Environment.fs
@@ -19,7 +19,7 @@ let userModel1() = userModelByName "user-model-1"
 
 let userModel2() = userModelByName "user-model-2"
 
-let expectError (msg : string) (sql : string) =
+let expectErrorWithModel (mkMsg : Model -> string) (sql : string) =
     let userModel = userModel1()
     try
         ignore <| CommandEffect.OfSQL(userModel.Model, "anonymous", sql)
@@ -27,7 +27,9 @@ let expectError (msg : string) (sql : string) =
     with
     | :? SourceException as exn ->
         printfn "\"%s\"" exn.Message
-        Assert.AreEqual(msg, exn.Reason.Trim())
+        Assert.AreEqual(mkMsg userModel.Model, exn.Reason.Trim())
+
+let expectError (msg : string) (sql : string) = expectErrorWithModel (fun _ -> msg) sql
 
 let dispenserParameterIndexer() =
     let dict = Dictionary()

--- a/src/Rezoom.SQL.Test/TestModelErrors.fs
+++ b/src/Rezoom.SQL.Test/TestModelErrors.fs
@@ -46,3 +46,8 @@ let ``no such column to index on creation`` () =
 let ``can't drop table referenced by others`` () =
     expectError (Error.tableIsReferencedByFKs "main.Users" ["main.UserGroupMaps"])
         "drop table Users"
+
+[<Test>]
+let ``non existing schema name`` () =
+    expectErrorWithModel (fun model -> Error.noSuchSchema model.Schemas "a")
+        "select * from a.b"


### PR DESCRIPTION
```fsharp
type Q = SQL<"select * from a.b">
```

before:

> key not found

after:

> Schema 'a' doesn't exist. Existing schemas: 'Main', 'Temp'.

- [x] add unit test
- [x] use failAt to generate better error message
- [x] check / deal for potential duplicate logic around Model.Schemas
